### PR TITLE
ページ全体の設定を追加 

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2,3 +2,24 @@
  *= require_tree .
  *= require_self
  */
+
+/* 全体 */
+
+.base-container {
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+/* max-width */
+
+.mw-md {
+  max-width: 720px;
+}
+
+.mw-lg {
+  max-width: 960px;
+}
+
+.mw-xl {
+  max-width: 1200px;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
-module ApplicationHelper
+module ApplicationHelper  
+  def max_width
+    "mw-xl"
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,15 @@
   </head>
 
   <body>
-    <%= yield %>
+    <header>
+    </header>
+    <main>
+      <#% max_width メソッドは application_helper.rb に記載 %>
+      <div class="base-container <%= max_width %>">
+        <%= yield %>
+      </div>
+    </main>
+    <footer>
+    </footer>
   </body>
 </html>


### PR DESCRIPTION
## close #11

## 実装内容

- ページ全体の設定を追加
  - 全ページに共通して必要なCSSを `app/assets/stylesheets/application.css` に設定
  - max_width メソッドを `app/helpers/application_helper.rb` に定義

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認