### PR TITLE
テキスト教材のcsvインポート機能を実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -47,3 +47,4 @@
 
 body {
   padding-top: 56px;
+}

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ module TeamProject
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
     config.i18n.default_locale = :ja
-    config.time_zone = 'Asia/Tokyo'
+    config.time_zone = "Asia/Tokyo"
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,5 +42,4 @@ ActiveRecord::Schema.define(version: 2021_03_19_082802) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
-
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,4 +42,5 @@ ActiveRecord::Schema.define(version: 2021_03_19_082802) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,3 +8,6 @@ end
 
 movie_path = "db/csv_data/movie_data.csv"
 ImportCsv.movie_data(movie_path)
+
+text_path = "db/csv_data/text_data.csv"
+ImportCsv.text_data(text_path)

--- a/lib/autoloads/import_csv.rb
+++ b/lib/autoloads/import_csv.rb
@@ -11,7 +11,7 @@ class ImportCsv
     end
     list
   end
-  
+
   def self.movie_data(path)
     list = import(path)
     puts "moviesテーブルのデータを削除"
@@ -23,8 +23,9 @@ class ImportCsv
 
   def self.text_data(path)
     list = import(path)
-    puts "インポート処理を開始"
+    puts "textsテーブルのデータを削除"
     Text.destroy_all
+    puts "インポート処理を開始"
     Text.create!(list)
     puts "インポート完了！！"
   end

--- a/lib/autoloads/import_csv.rb
+++ b/lib/autoloads/import_csv.rb
@@ -20,4 +20,12 @@ class ImportCsv
     Movie.create!(list)
     puts "インポート完了!!"
   end
+
+  def self.text_data(path)
+    list = import(path)
+    puts "インポート処理を開始"
+    Text.destroy_all
+    Text.create!(list)
+    puts "インポート完了！！"
+  end
 end


### PR DESCRIPTION
## issue 番号
close #18 

## 実装内容

* `db/seeds.rb`に，テキスト教材のCSV（`db/csv_data/text_data.csv`）を読み込み texts テーブルにデータを投入する処理を追加
  * 先に `Text.destroy_all` を入れ，実行時にデータを初期化できるようにしておくこと
  * `rails db:seed` を実行し，Railsコンソールなどで初期データが入ることを確認すること
## 参考文献
* [やんばるエキスパート教材（CSVインポート）](https://www.yanbaru-code.com/texts/217)